### PR TITLE
Add Python 3.8 to CI-Tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
It's probably time to start testing Python 3.8, since my Home-Assistant also runs on it.

I packaged PyRMVtransport for NixOS, when I noticed some warnings on Python3.8 resulting from aiohttp:

```
============================= test session starts ==============================
platform linux -- Python 3.8.3, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
rootdir: /build/source
plugins: cov-2.9.0, asyncio-0.12.0, mock-3.1.1, aiohttp-0.3.0, aresponses-2.0.0
collected 14 items

tests/test_bugs.py .                                                     [  7%]
tests/test_rmvtransport.py ..xxxx.xx..xx                                 [100%]

=============================== warnings summary ===============================
tests/test_bugs.py: 1 test with warning
tests/test_rmvtransport.py: 12 tests with warnings
  /nix/store/vzn857kqjgfq78hk2k8mpfvzb08r24gg-python3.8-aiohttp-3.6.2/lib/python3.8/site-packages/aiohttp/connector.py:964: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
    hosts = await asyncio.shield(self._resolve_host(

tests/test_rmvtransport.py::test_no_station_id
  /nix/store/vzn857kqjgfq78hk2k8mpfvzb08r24gg-python3.8-aiohttp-3.6.2/lib/python3.8/site-packages/aiohttp/web_server.py:53: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
    await asyncio.gather(*coros, loop=self._loop)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform linux, python 3.8.3-final-0 -----------
Name                           Stmts   Miss  Cover
--------------------------------------------------
RMVtransport/__init__.py           2      0   100%
RMVtransport/const.py              5      0   100%
RMVtransport/errors.py             4      0   100%
RMVtransport/rmvjourney.py        72      2    97%
RMVtransport/rmvtransport.py     137      0   100%
--------------------------------------------------
TOTAL                            220      2    99%

================== 6 passed, 8 xfailed, 14 warnings in 0.91s ===================
```