### PR TITLE
Compatibility for async_timeout 4.0.0

### DIFF
--- a/RMVtransport/rmvtransport.py
+++ b/RMVtransport/rmvtransport.py
@@ -148,7 +148,7 @@ class RMVtransport:
 
     async def _query_rmv_api(self, url: str) -> Any:
         """Query RMV API."""
-        with async_timeout.timeout(self._timeout):
+        async with async_timeout.timeout(self._timeout):
             async with httpx.AsyncClient() as client:
                 try:
                     response = await client.get(url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ home-page = "https://github.com/cgtobi/PyRMVtransport"
 license = "MIT"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires = [
-    "async-timeout",
+    "async-timeout>=4.0.0",
     "lxml",
     "httpx"
 ]


### PR DESCRIPTION
Ensures it works with async_timeout 4, which is now part of Home Assistant.

Noticed this one when working on Python 3.10 and a newer `pip` version:

```txt
ERROR: Cannot install -r requirements_test_all.txt (line 118), -r requirements_test_all.txt (line 24) and -r requirements_test_all.txt (line 54) because these package versions have conflicting dependencies.

The conflict is caused by:
    pyrmvtransport 0.3.2 depends on async-timeout
    adax 0.1.1 depends on async-timeout>=1.4.0
    aioguardian 1.0.8 depends on async_timeout<4.0.0 and >=3.0.1
    The user requested (constraint) async-timeout==4.0.0
```