### PR TITLE
Remove async_timeout and update python versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/RMVtransport/__init__.py
+++ b/RMVtransport/__init__.py
@@ -1,4 +1,5 @@
 """Python library to make use of transport information from opendata.rmv.de."""
+
 # pylint: disable=C0103
 from .rmvtransport import RMVtransport  # noqa
 

--- a/RMVtransport/const.py
+++ b/RMVtransport/const.py
@@ -1,6 +1,6 @@
 """Constants."""
-from typing import List, Dict
 
+from typing import List, Dict
 
 PRODUCTS: Dict[str, int] = {
     "ICE": 1,

--- a/RMVtransport/rmvjourney.py
+++ b/RMVtransport/rmvjourney.py
@@ -1,4 +1,5 @@
 """This class represents a single journey."""
+
 import html
 import logging
 from datetime import datetime, timedelta

--- a/RMVtransport/rmvtransport.py
+++ b/RMVtransport/rmvtransport.py
@@ -7,7 +7,6 @@ import urllib.request
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-import async_timeout
 import httpx
 from lxml import etree, objectify  # type: ignore
 
@@ -148,7 +147,7 @@ class RMVtransport:
 
     async def _query_rmv_api(self, url: str) -> Any:
         """Query RMV API."""
-        async with async_timeout.timeout(self._timeout):
+        async with asyncio.timeout(self._timeout):
             async with httpx.AsyncClient() as client:
                 try:
                     response = await client.get(url)

--- a/RMVtransport/rmvtransport.py
+++ b/RMVtransport/rmvtransport.py
@@ -1,4 +1,5 @@
 """A module to query bus and train departure times."""
+
 import asyncio
 import json
 import logging

--- a/RMVtransport/rmvtravel.py
+++ b/RMVtransport/rmvtravel.py
@@ -1,4 +1,5 @@
 """This class represents a collection of journeys."""
+
 from collections import UserDict
 from typing import Dict, List
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,10 @@ home-page = "https://github.com/cgtobi/PyRMVtransport"
 license = "MIT"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires = [
-    "async-timeout>=4.0.0",
     "lxml",
     "httpx"
 ]
-requires-python=">=3.7"
+requires-python=">=3.11"
 description-file="README.md"
 
 [tool.flit.metadata.requires-extra]

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ URL_SEARCH_PATH = "/auskunft/bin/jp/ajax-getstop.exe/dn"
 
 def date_hook(json_dict):
     """JSON datetime parser."""
-    for (key, value) in json_dict.items():
+    for key, value in json_dict.items():
         try:
             json_dict[key] = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
         except (TypeError, ValueError):

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -1,11 +1,11 @@
 """Define tests for the client object."""
+
 from datetime import datetime
 import logging
 
 import pytest
 
 from RMVtransport import RMVtransport
-
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ URL_SEARCH_PATH = "/auskunft/bin/jp/ajax-getstop.exe/dn"
 
 def date_hook(json_dict):
     """JSON datetime parser."""
-    for (key, value) in json_dict.items():
+    for key, value in json_dict.items():
         try:
             json_dict[key] = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
         except (TypeError, ValueError):

--- a/tests/test_rmvtransport.py
+++ b/tests/test_rmvtransport.py
@@ -1,4 +1,5 @@
 """Define tests for the client object."""
+
 import json
 import httpx
 


### PR DESCRIPTION
## Summary by Sourcery

Update async timeout handling and modernize supported Python versions.

Enhancements:
- Replace async_timeout usage with asyncio.timeout in RMV API query logic to rely on the standard library.
- Tidy test helper date parsing loops and logging setup for minor style consistency.

CI:
- Update GitHub Actions test matrix to run against Python 3.11 through 3.14 instead of 3.8 through 3.10.